### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As it doesnt go above 24hrs either way ¯\\\_(ツ)\_/¯
 **Building**  
 To build EasyRP from source you need the following
   - any c++ compiler (cl, g++, clang++, etc)
-  - Meson
+  - Meson (0.45 or higher)
   - Ninja
   - CMake (for discord-rpc library)  
   


### PR DESCRIPTION
It won't build on meson older than 0.45 because of `'b_ndebug=if-release'` https://github.com/mesonbuild/meson/blob/master/docs/markdown/Release-notes-for-0.45.0.md#b_ndebug--if-release